### PR TITLE
Fixes trophy.dm

### DIFF
--- a/modular_event/trophy/trophy.dm
+++ b/modular_event/trophy/trophy.dm
@@ -1,4 +1,4 @@
-obj/item/silver_trophy
+/obj/item/silver_trophy
 	name = "silver trophy"
 	desc = "A silver trophy depicting the Milky Way, designated for the runner-up team."
 	icon_state = "silver_trophy"


### PR DESCRIPTION

## About The Pull Request

turns out there was a missing "/" in the code, causing trophies to not work. Fun!!!

## Changelog

:cl:
fix: fixes trophy code
/:cl: