### PR TITLE
Fixes yorked lighting and yorked cameras

### DIFF
--- a/code/datums/components/seethrough.dm
+++ b/code/datums/components/seethrough.dm
@@ -96,8 +96,8 @@
 ///Apply the trickery image and animation
 /datum/component/seethrough/proc/trick_mob(mob/fool)
 	var/datum/hud/our_hud = fool.hud_used
-	var/atom/movable/screen/plane_master/seethrough = our_hud.get_plane_master(SEETHROUGH_PLANE)
-	seethrough.unhide_plane(fool)
+	for(var/atom/movable/screen/plane_master/seethrough in our_hud.get_true_plane_masters(SEETHROUGH_PLANE))
+		seethrough.unhide_plane(fool)
 
 	var/image/user_overlay = new(parent)
 	user_overlay.loc = parent
@@ -140,8 +140,9 @@
 		fool.client?.images -= trickery_image
 		UnregisterSignal(fool, COMSIG_MOB_LOGOUT)
 		var/datum/hud/our_hud = fool.hud_used
-		var/atom/movable/screen/plane_master/seethrough = our_hud.get_plane_master(SEETHROUGH_PLANE)
-		seethrough.hide_plane(fool)
+
+		for(var/atom/movable/screen/plane_master/seethrough in our_hud.get_true_plane_masters(SEETHROUGH_PLANE))
+			seethrough.hide_plane(fool)
 
 	tricked_mobs.Cut()
 
@@ -153,5 +154,5 @@
 	UnregisterSignal(fool, COMSIG_MOB_LOGOUT)
 	RegisterSignal(fool, COMSIG_MOB_LOGIN, .proc/trick_mob)
 	var/datum/hud/our_hud = fool.hud_used
-	var/atom/movable/screen/plane_master/seethrough = our_hud.get_plane_master(SEETHROUGH_PLANE)
-	seethrough.hide_plane(fool)
+	for(var/atom/movable/screen/plane_master/seethrough in our_hud.get_true_plane_masters(SEETHROUGH_PLANE))
+		seethrough.hide_plane(fool)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -92,8 +92,8 @@
 	user.remote_control = null
 	current_user = null
 	user.unset_machine()
-	var/atom/movable/screen/plane_master/plane_static = user.hud_used?.get_plane_master(CAMERA_STATIC_PLANE)
-	if(plane_static)
+
+	for(var/atom/movable/screen/plane_master/plane_static in user.hud_used?.get_true_plane_masters(CAMERA_STATIC_PLANE))
 		plane_static.hide_plane(user)
 	playsound(src, 'sound/machines/terminal_off.ogg', 25, FALSE)
 
@@ -180,8 +180,7 @@
 	if(should_supress_view_changes)
 		user.client.view_size.supress()
 	// Who passes control like this god I hate static code
-	var/atom/movable/screen/plane_master/plane_static = user.hud_used?.get_plane_master(CAMERA_STATIC_PLANE)
-	if(plane_static)
+	for(var/atom/movable/screen/plane_master/plane_static in user.hud_used?.get_true_plane_masters(CAMERA_STATIC_PLANE))
 		plane_static.unhide_plane(user)
 
 /mob/camera/ai_eye/remote

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(SSmapping.z_level_to_plane_offset[z])
 		var/area/thisarea = get_area(W)
 		if(thisarea.lighting_effects)
-			W.add_overlay(thisarea.lighting_effects[SSmapping.z_level_to_plane_offset[z]])
+			W.add_overlay(thisarea.lighting_effects[SSmapping.z_level_to_plane_offset[z] + 1])
 
 	QUEUE_SMOOTH_NEIGHBORS(src)
 	QUEUE_SMOOTH(src)

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -103,7 +103,7 @@
 	// We will only run this logic on turfs off the prime z layer
 	// Since on the prime z layer, we use an overlay on the area instead, to save time
 	if(SSmapping.z_level_to_plane_offset[z])
-		var/index = SSmapping.z_level_to_plane_offset[z]
+		var/index = SSmapping.z_level_to_plane_offset[z] + 1
 		//Inherit overlay of new area
 		if(old_area.lighting_effects)
 			cut_overlay(old_area.lighting_effects[index])

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -231,7 +231,7 @@
 	. = ..()
 	if(!.)
 		return
-	var/atom/game_renderer = mod.wearer.hud_used.get_plane_master(RENDER_PLANE_GAME)
+	var/atom/game_renderer = mod.wearer.hud_used.get_plane_master(MUTATE_PLANE(RENDER_PLANE_GAME, mod.wearer))
 	var/matrix/render_matrix = matrix(game_renderer.transform)
 	render_matrix.Scale(1.25, 1.25)
 	animate(game_renderer, launch_time, flags = SINE_EASING|EASE_IN, transform = render_matrix)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
[Fixes some uses of plane masters that only specified one rather then all](https://github.com/tgstation/event-toolbox-tournament-2022/commit/7b51c8a3eacad742bb2972761f880f1bd4d0b843)

We almost never only want to show SOME hidden planes. Should really make
a helper for this someday

[Fixes area lighting not working on turf change in multiz cases](https://github.com/tgstation/event-toolbox-tournament-2022/commit/9b5551084dd4093d0906f7de20fc1fd7fb8429ea)

If you modify a area lit turf when using multiz, it'd end up using the
wrong plane for its light, because of stupid shit on my part. stupid
shit resolved