### PR TITLE
Fixes hud images sourced from things created in nullspace not showing

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -136,16 +136,16 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!new_viewer)
 		return
 
-	var/turf/their_turf = get_turf(new_viewer)
-	if(!their_turf)
-		return
-
-	if(!hud_users[their_turf.z][new_viewer])
-		hud_users[their_turf.z][new_viewer] = TRUE
+	if(!hud_users_all_z_levels[new_viewer])
 		hud_users_all_z_levels[new_viewer] = 1
 
 		RegisterSignal(new_viewer, COMSIG_PARENT_QDELETING, .proc/unregister_atom, override = TRUE) //both hud users and hud atoms use these signals
 		RegisterSignal(new_viewer, COMSIG_MOVABLE_Z_CHANGED, .proc/on_atom_or_user_z_level_changed, override = TRUE)
+
+		var/turf/their_turf = get_turf(new_viewer)
+		if(!their_turf)
+			return
+		hud_users[their_turf.z][new_viewer] = TRUE
 
 		if(next_time_allowed[new_viewer] > world.time)
 			if(!queued_to_see[new_viewer])
@@ -165,10 +165,6 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!former_viewer || !hud_users_all_z_levels[former_viewer])
 		return
 
-	var/turf/their_turf = get_turf(former_viewer)
-	if(!their_turf)
-		return
-
 	hud_users_all_z_levels[former_viewer] -= 1//decrement number of sources for this hud on this user (bad way to track i know)
 
 	if (absolute || hud_users_all_z_levels[former_viewer] <= 0)//if forced or there arent any sources left, remove the user
@@ -177,15 +173,18 @@ GLOBAL_LIST_INIT(huds, list(
 			UnregisterSignal(former_viewer, COMSIG_MOVABLE_Z_CHANGED)
 			UnregisterSignal(former_viewer, COMSIG_PARENT_QDELETING)
 
-		hud_users[their_turf.z] -= former_viewer
 		hud_users_all_z_levels -= former_viewer
 
 		if(next_time_allowed[former_viewer])
 			next_time_allowed -= former_viewer
 
+		var/turf/their_turf = get_turf(former_viewer)
+		if(their_turf)
+			hud_users[their_turf.z] -= former_viewer
+
 		if(queued_to_see[former_viewer])
 			queued_to_see -= former_viewer
-		else
+		else if (their_turf)
 			for(var/atom/hud_atom as anything in get_hud_atoms_for_z_level(their_turf.z))
 				remove_atom_from_single_hud(former_viewer, hud_atom)
 
@@ -193,15 +192,17 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/add_atom_to_hud(atom/new_hud_atom)
 	if(!new_hud_atom)
 		return FALSE
-	var/turf/atom_turf = get_turf(new_hud_atom)
-	if(!atom_turf)
-		return
 
+	// No matter where or who you are, you matter to me :)
 	RegisterSignal(new_hud_atom, COMSIG_MOVABLE_Z_CHANGED, .proc/on_atom_or_user_z_level_changed, override = TRUE)
 	RegisterSignal(new_hud_atom, COMSIG_PARENT_QDELETING, .proc/unregister_atom, override = TRUE) //both hud atoms and hud users use these signals
+	hud_atoms_all_z_levels[new_hud_atom] = TRUE
+
+	var/turf/atom_turf = get_turf(new_hud_atom)
+	if(!atom_turf)
+		return TRUE
 
 	hud_atoms[atom_turf.z] |= new_hud_atom
-	hud_atoms_all_z_levels[new_hud_atom] = TRUE
 
 	for(var/mob/mob_to_show as anything in get_hud_users_for_z_level(atom_turf.z))
 		if(!queued_to_see[mob_to_show])
@@ -221,12 +222,13 @@ GLOBAL_LIST_INIT(huds, list(
 	for(var/mob/mob_to_remove as anything in hud_users_all_z_levels)
 		remove_atom_from_single_hud(mob_to_remove, hud_atom_to_remove)
 
+	hud_atoms_all_z_levels -= hud_atom_to_remove
+
 	var/turf/atom_turf = get_turf(hud_atom_to_remove)
 	if(!atom_turf)
-		return
+		return TRUE
 
 	hud_atoms[atom_turf.z] -= hud_atom_to_remove
-	hud_atoms_all_z_levels -= hud_atom_to_remove
 
 	return TRUE
 
@@ -235,13 +237,13 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!hud_atom?.active_hud_list?[hud_category_to_add] || QDELING(hud_atom) || !(hud_category_to_add in hud_icons))
 		return FALSE
 
-	var/turf/atom_turf = get_turf(hud_atom)
-	if(!atom_turf)
-		return FALSE
-
 	if(!hud_atoms_all_z_levels[hud_atom])
 		add_atom_to_hud(hud_atom)
 		return TRUE
+
+	var/turf/atom_turf = get_turf(hud_atom)
+	if(!atom_turf)
+		return FALSE
 
 	for(var/mob/hud_user as anything in get_hud_users_for_z_level(atom_turf.z))
 		if(!hud_user.client)


### PR DESCRIPTION
Z hud code made the assertion that if something had no turf, we would not be interested in it.
This broke when we spawned something in nullspace, gave it some hud images, and the moved it onto a z level.

I'm doing my best here to seperate the "registration" from the actual addition. 